### PR TITLE
review suggestions for network rm --force

### DIFF
--- a/cli/command/network/remove_test.go
+++ b/cli/command/network/remove_test.go
@@ -6,28 +6,92 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNetworkRemoveForce(t *testing.T) {
-	fakeCli := test.NewFakeCli(&fakeClient{
-		networkRemoveFunc: func(ctx context.Context, networkID string) error {
-			if networkID == "foo" {
-				return errors.Errorf("")
-			}
-			return nil
+	tests := []struct {
+		doc         string
+		args        []string
+		expectedErr string
+	}{
+		{
+			doc:  "existing network",
+			args: []string{"existing-network"},
 		},
-	})
+		{
+			doc:  "existing network (forced)",
+			args: []string{"--force", "existing-network"},
+		},
+		{
+			doc:         "non-existing network",
+			args:        []string{"no-such-network"},
+			expectedErr: "no such network: no-such-network",
+		},
+		{
+			doc:  "non-existing network (forced)",
+			args: []string{"--force", "no-such-network"},
+		},
+		{
+			doc:         "in-use network",
+			args:        []string{"in-use-network"},
+			expectedErr: "network is in use",
+		},
+		{
+			doc:         "in-use network (forced)",
+			args:        []string{"--force", "in-use-network"},
+			expectedErr: "network is in use",
+		},
+		{
+			doc:         "multiple networks",
+			args:        []string{"existing-network", "no-such-network"},
+			expectedErr: "no such network: no-such-network",
+		},
+		{
+			doc:  "multiple networks (forced)",
+			args: []string{"--force", "existing-network", "no-such-network"},
+		},
+		{
+			doc:         "multiple networks 2 (forced)",
+			args:        []string{"--force", "existing-network", "no-such-network", "in-use-network"},
+			expectedErr: "network is in use",
+		},
+	}
 
-	cmd := newRemoveCommand(fakeCli)
-	cmd.SetOut(io.Discard)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			fakeCli := test.NewFakeCli(&fakeClient{
+				networkRemoveFunc: func(ctx context.Context, networkID string) error {
+					switch networkID {
+					case "no-such-network":
+						return errdefs.NotFound(errors.New("no such network: no-such-network"))
+					case "in-use-network":
+						return errdefs.Forbidden(errors.New("network is in use"))
+					case "existing-network":
+						return nil
+					default:
+						return nil
+					}
+				},
+			})
 
-	cmd.SetArgs([]string{"foo"})
-	// 'network rm' currently only returns a generic error string that only states the
-	// non-zero exit code.
-	assert.ErrorContains(t, cmd.Execute(), "Code: 1")
+			cmd := newRemoveCommand(fakeCli)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(fakeCli.ErrBuffer())
+			cmd.SetArgs(tc.args)
 
-	cmd.SetArgs([]string{"--force", "foo"})
-	assert.NilError(t, cmd.Execute())
+			err := cmd.Execute()
+			if tc.expectedErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.Check(t, is.Contains(fakeCli.ErrBuffer().String(), tc.expectedErr))
+				assert.ErrorContains(t, err, "Code: 1")
+
+			}
+		})
+	}
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3494,7 +3494,7 @@ _docker_network_prune() {
 _docker_network_rm() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--force -f --help" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_networks --filter type=custom

--- a/docs/reference/commandline/network_rm.md
+++ b/docs/reference/commandline/network_rm.md
@@ -15,7 +15,7 @@ Aliases:
   rm, remove
 
 Options:
-  -f, --force   Force the removal of a network
+  -f, --force   Do not error if the network does not exist
 ```
 
 ## Description


### PR DESCRIPTION
relates to https://github.com/docker/cli/pull/3547

- update flag description (better suggestions welcome :))
- remove API version annotation (as it's a client-only change)
- selectively ignore "not found" errors (continue to fail for other reasons)
- update test to use sub-tests, and include various combinations.
- add flag to the bash completion script

